### PR TITLE
Explode: Use null coalescing operator to provide empty string default

### DIFF
--- a/src/Console/Traits/ArrayOption.php
+++ b/src/Console/Traits/ArrayOption.php
@@ -12,6 +12,6 @@ trait ArrayOption
      */
     protected function arrayOption(string $key, string $delimiter = ','): array
     {
-        return array_filter(explode($delimiter, $this->option($key)));
+        return array_filter(explode($delimiter, $this->option($key) ?? ''));
     }
 }

--- a/src/Console/Traits/RequiredArrayOption.php
+++ b/src/Console/Traits/RequiredArrayOption.php
@@ -16,6 +16,6 @@ trait RequiredArrayOption
      */
     protected function requiredArrayOption(string $key, string $delimiter = ','): array
     {
-        return array_filter(explode($delimiter, $this->requiredOption($key)));
+        return array_filter(explode($delimiter, $this->requiredOption($key) ?? ''));
     }
 }

--- a/src/Jobs/DebouncedJob.php
+++ b/src/Jobs/DebouncedJob.php
@@ -116,7 +116,7 @@ class DebouncedJob implements ShouldQueue
 
     protected function setDebounce() : void
     {
-        Cache::put($this->getDebounceKey(), true, now()->addMilliseconds($this->getWaitTime() *2));
+        Cache::put($this->getDebounceKey(), true, now()->addMilliseconds($this->getWaitTime() * 2));
     }
 
     protected function getDebounceKey() : string
@@ -145,6 +145,7 @@ class DebouncedJob implements ShouldQueue
 
         Cache::put($this->getMaximumWaitTimeKey(), $maximum, $maximum?->addMinute());
     }
+
     protected function getMaximumWaitTimeKey() : string
     {
         return $this->getCacheKey() . ':maximum';


### PR DESCRIPTION
## Description

In PHP 8.1 passing null as the `explode` function's second parameter became deprecated. This updates the uses of explode in the ArrayOption traits to default to an empty string in these cases

## Release Notes

No change in functionality but deprecation notices should stop appearing for these cases

## Types of changes

- [x] Bugfix
- [ ] New feature
- [x] Chore (mundane code change)
- [ ] Maintenance (clean up)

## Checklist

- [x] Unit tests pass locally
- [ ] Added tests to code that was updated or edited
- [ ] Updated/added documentation